### PR TITLE
optimize setting up problem

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,3 +13,6 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/src/npa_impl.jl
+++ b/src/npa_impl.jl
@@ -128,7 +128,7 @@ function sdp2jump(expr, ineqs;
           for (m, n) in size_as_pair.(ineqs)]
 
     Ids = (ineq[Id] for ineq in ineqs)
-    objective = (sum(LinearAlgebra.tr(s*m*z)
+    objective = (s*sum(LinearAlgebra.dot(m,z)
                      for (m, z) in zip(Ids, Zs))
                  + expr[Id])
 
@@ -143,7 +143,7 @@ function sdp2jump(expr, ineqs;
     for m in mons
         c = expr[m]
         Fs = (ineq[m] for ineq in ineqs)
-        tr_term = sum(LinearAlgebra.tr(F*Z)
+        tr_term = sum(LinearAlgebra.dot(F,Z)
                       for (F, Z) in zip(Fs, Zs))
 
         @constraint(model, tr_term + s*c == 0)

--- a/src/npa_impl.jl
+++ b/src/npa_impl.jl
@@ -108,7 +108,18 @@ function set_verbosity!(model, verbose)
     end
 end
 
-
+#this is required so that dot used in sdp2jump has acceptable performance
+import LinearAlgebra.dot
+function dot(A::SparseMatrixCSC, B::Symmetric{<:JuMP._MA.AbstractMutable})
+    acc = zero(eltype(B))
+    for j in 1:size(A, 2)
+        for k in nzrange(A, j)
+            add_to_expression!(acc, nonzeros(A)[k], B[rowvals(A)[k], j])
+        end
+    end
+    return acc
+end
+dot(A::Symmetric{<:JuMP._MA.AbstractMutable}, B::SparseMatrixCSC) = dot(B,A)
 
 function sdp2jump(expr, ineqs;
                   goal=:maximise,
@@ -128,7 +139,7 @@ function sdp2jump(expr, ineqs;
           for (m, n) in size_as_pair.(ineqs)]
 
     Ids = (ineq[Id] for ineq in ineqs)
-    objective = (s*sum(LinearAlgebra.dot(m,z)
+    objective = (s*sum(dot(m,z)
                      for (m, z) in zip(Ids, Zs))
                  + expr[Id])
 
@@ -143,7 +154,7 @@ function sdp2jump(expr, ineqs;
     for m in mons
         c = expr[m]
         Fs = (ineq[m] for ineq in ineqs)
-        tr_term = sum(LinearAlgebra.dot(F,Z)
+        tr_term = sum(dot(F,Z)
                       for (F, Z) in zip(Fs, Zs))
 
         @constraint(model, tr_term + s*c == 0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -58,6 +58,7 @@ using Test
 end
 
 @testset "Test with matrix coefficients               " begin
+    @dichotomic A1 B1
     P = [1 0; 0 1] * Id + [0 1; 1 0] * A1
     Q = [1 2; 3 4] * Id + [5 6; 7 8] * B1
     R = [1 2; 3 4] * Id + [3 4; 1 2] * A1 + [5 6; 7 8] * B1 + [7 8; 5 6] * A1*B1
@@ -89,6 +90,7 @@ end
     @test Q isa Polynomial
     @test !(Q isa Monomial)
 
+    @dichotomic A1 A2 B1 B2
     S = A1*B1 + A1*B2 + A2*B1 - A2*B2
     @test S isa Polynomial
 


### PR DESCRIPTION
As I mentioned before in #2, changing from `tr(F*Z)` to `dot(F, Z)` dramatically improves performance, so I'm submitting it as a PR here. I also did a couple of fixes to the tests so everything would run.

For benchmarking I used the code

```julia
using QuantumNPA
using MosekTools
using JuMP

function benchmark()
    @dichotomic A1 A2 B1 B2
    S = A1 * (B1 + B2) + A2 * (B1 - B2)

    for level in 1:16
        println("Level $level:")
        gamma = npa_moment(S, level)
        @time model = npa2jump(S, gamma; solver = Mosek.Optimizer)
    end
end
```

Before the change I got
```julia
Level 1:
  0.000920 seconds (5.54 k allocations: 266.219 KiB)
Level 2:
  0.001654 seconds (40.01 k allocations: 2.812 MiB)
Level 3:
  0.013942 seconds (252.50 k allocations: 18.960 MiB, 48.40% gc time)
Level 4:
  0.024541 seconds (1.08 M allocations: 82.240 MiB)
Level 5:
  0.111893 seconds (3.50 M allocations: 269.043 MiB, 17.43% gc time)
Level 6:
  0.282036 seconds (9.40 M allocations: 724.695 MiB, 14.52% gc time)
Level 7:
  0.685988 seconds (22.00 M allocations: 1.659 GiB, 15.45% gc time)
Level 8:
  1.549258 seconds (46.36 M allocations: 3.501 GiB, 15.54% gc time)
Level 9:
  3.607801 seconds (90.01 M allocations: 6.798 GiB, 23.36% gc time)
Level 10:
  6.860917 seconds (163.63 M allocations: 12.359 GiB, 15.32% gc time)
Level 11:
 14.217260 seconds (281.84 M allocations: 21.294 GiB, 19.05% gc time)
Level 12:
 25.891500 seconds (464.09 M allocations: 35.058 GiB, 19.29% gc time)
Level 13:
 45.181614 seconds (735.46 M allocations: 55.565 GiB, 20.28% gc time)
Level 14:
 74.688912 seconds (1.13 G allocations: 85.201 GiB, 21.90% gc time)
Level 15:
117.945080 seconds (1.68 G allocations: 126.985 GiB, 22.33% gc time)
Level 16:
177.768142 seconds (2.44 G allocations: 184.620 GiB, 22.56% gc time)
```

And after it
```julia
Level 1:
  0.269014 seconds (506.21 k allocations: 34.541 MiB, 14.69% gc time, 99.57% compilation time)
Level 2:
  0.001372 seconds (37.29 k allocations: 1.503 MiB)
Level 3:
  0.003807 seconds (240.13 k allocations: 9.833 MiB)
Level 4:
  0.014111 seconds (1.04 M allocations: 42.509 MiB)
Level 5:
  0.090406 seconds (3.40 M allocations: 139.224 MiB)
Level 6:
  0.224277 seconds (9.20 M allocations: 375.420 MiB, 12.35% gc time)
Level 7:
  0.551686 seconds (21.60 M allocations: 881.630 MiB, 17.85% gc time)
Level 8:
  1.137214 seconds (45.64 M allocations: 1.820 GiB, 16.84% gc time)
Level 9:
  2.158229 seconds (88.78 M allocations: 3.536 GiB, 17.26% gc time)
Level 10:
  3.839511 seconds (161.64 M allocations: 6.433 GiB, 17.50% gc time)
Level 11:
  6.458086 seconds (278.72 M allocations: 11.093 GiB, 16.74% gc time)
Level 12:
 10.558023 seconds (459.40 M allocations: 18.276 GiB, 17.05% gc time)
Level 13:
 16.585933 seconds (728.60 M allocations: 28.987 GiB, 17.13% gc time)
Level 14:
 25.178052 seconds (1.12 G allocations: 44.473 GiB, 17.12% gc time)
Level 15:
 37.362517 seconds (1.67 G allocations: 66.321 GiB, 17.20% gc time)
Level 16:
 54.556266 seconds (2.43 G allocations: 96.482 GiB, 17.40% gc time)
```
Now what made the time become comparable to moment was to set up the primal instead of the dual. I wrote a primal version of the function:
```julia
function sdp2jump_primal(expr, ineqs; goal = :maximise, solver = nothing, verbose = nothing)
    if goal in (:maximise, :maximize, :max)
        maximise = true
        s = 1
    elseif goal in (:minimise, :minimize, :min)
        maximise = false
        s = -1
    end

    model = !isnothing(solver) ? Model(solver) : Model()

    mons = collect(m for m in monomials(expr, ineqs) if !isidentity(m))
    coeffs = [expr[m] for m in mons]
    
    nvars = length(mons)
    @variable(model, x[1:nvars])

    objective = expr[Id] + LinearAlgebra.dot(coeffs,x)
    if maximise
        @objective(model, Min, objective)
    else
        @objective(model, Max, objective)
    end

    Fs = [ineqs[1][m] for m in mons]

    d = size(ineqs[1])[1]    
    bigF = spzeros(d^2, nvars)
    for i = 1:nvars
        bigF[:,i] .= vec(ineqs[1][mons[i]])
    end
    
    moment_matrix = ineqs[1][Id] + reshape(bigF*x,d,d)
    @constraint(model, LinearAlgebra.Symmetric(moment_matrix) in PSDCone())
    set_verbosity!(model, verbose)

    return model
end
```
And with it the times are:
```julia
Level 1:
  0.002385 seconds (4.49 k allocations: 170.281 KiB)
Level 2:
  0.001507 seconds (8.96 k allocations: 423.141 KiB)
Level 3:
  0.001799 seconds (21.99 k allocations: 1.184 MiB)
Level 4:
  0.003552 seconds (46.68 k allocations: 2.838 MiB)
Level 5:
  0.008864 seconds (91.25 k allocations: 5.992 MiB)
Level 6:
  0.019090 seconds (173.10 k allocations: 11.520 MiB)
Level 7:
  0.044233 seconds (285.85 k allocations: 20.156 MiB)
Level 8:
  0.086811 seconds (448.05 k allocations: 32.428 MiB)
Level 9:
  0.141756 seconds (673.39 k allocations: 50.452 MiB)
Level 10:
  0.262950 seconds (977.21 k allocations: 73.765 MiB)
Level 11:
  0.428602 seconds (1.37 M allocations: 107.310 MiB)
Level 12:
  0.725241 seconds (1.94 M allocations: 148.197 MiB, 3.46% gc time)
Level 13:
  1.108296 seconds (2.59 M allocations: 200.118 MiB)
Level 14:
  1.744433 seconds (3.39 M allocations: 265.745 MiB, 3.24% gc time)
Level 15:
  2.625790 seconds (4.36 M allocations: 343.377 MiB, 5.41% gc time)
Level 16:
  4.130944 seconds (5.53 M allocations: 443.056 MiB, 11.99% gc time)
```
Unfortunately when we send the primal problem to MOSEK it becomes really, really slow. One can see that it is indeed solving the primal instead of the dual, and apparently this doesn't work for this problem.

Now there should be a way to get the setup up time as fast as the primal and the solution time as fast as the dual, I'll write to the JuMP devs to see if they know.