### PR TITLE
fix: add Julia 1.12 compatibility for LinearAlgebra.dot with JuMP variables

### DIFF
--- a/src/npa_impl.jl
+++ b/src/npa_impl.jl
@@ -157,8 +157,8 @@ The main purpose of this function is to eliminate equality constraints from
 the input problem. This function also takes a representation of the real part
 of the input problem, if it isn't already real-valued.
 
-The return value is a tuple containing 1) the expression to optimise, and 2) a
-vector of matrices that will be required to be positive semidefinite. The
+The return value is a tuple containing 1) the expression to optimise, and 2)
+a vector of matrices that will be required to be positive semidefinite. The
 first element of the vector is derived from the input moment matrix; any
 additional ones are derived from any additional inequality constraints
 provided.
@@ -237,10 +237,12 @@ end
 
 
 
-# This is required so that dot used in sdp2jump_d has acceptable performance
-# Made more specific (Matrix instead of AbstractMatrix) to avoid ambiguity in Julia 1.12
+# This is required so that dot used in sdp2jump_d has acceptable performance.
+# Made more specific (Matrix instead of AbstractMatrix) to avoid ambiguity in
+# Julia 1.12
 function LinearAlgebra.dot(A::SparseMatrixCSC,
-        B::Symmetric{<:JuMP._MA.AbstractMutable, Matrix{<:JuMP._MA.AbstractMutable}})
+                           B::Symmetric{<:JuMP._MA.AbstractMutable,
+                                        Matrix{<:JuMP._MA.AbstractMutable}})
     acc = zero(eltype(B))
 
     for j in 1:size(A, 2)
@@ -252,7 +254,8 @@ function LinearAlgebra.dot(A::SparseMatrixCSC,
     return acc
 end
 
-function LinearAlgebra.dot(A::Symmetric{<:JuMP._MA.AbstractMutable,Matrix{<:JuMP._MA.AbstractMutable}},
+function LinearAlgebra.dot(A::Symmetric{<:JuMP._MA.AbstractMutable,
+                                        Matrix{<:JuMP._MA.AbstractMutable}},
                            B::SparseMatrixCSC)
     return dot(B, A)
 end

--- a/src/npa_impl.jl
+++ b/src/npa_impl.jl
@@ -240,7 +240,7 @@ end
 # This is required so that dot used in sdp2jump_d has acceptable performance
 # Made more specific (Matrix instead of AbstractMatrix) to avoid ambiguity in Julia 1.12
 function LinearAlgebra.dot(A::SparseMatrixCSC,
-                           B::Symmetric{<:JuMP._MA.AbstractMutable, <:Matrix})
+        B::Symmetric{<:JuMP._MA.AbstractMutable, Matrix{<:JuMP._MA.AbstractMutable}})
     acc = zero(eltype(B))
 
     for j in 1:size(A, 2)
@@ -252,27 +252,7 @@ function LinearAlgebra.dot(A::SparseMatrixCSC,
     return acc
 end
 
-function LinearAlgebra.dot(A::Symmetric{<:JuMP._MA.AbstractMutable, <:Matrix},
-                           B::SparseMatrixCSC)
-    return dot(B, A)
-end
-
-# Julia 1.12 compatibility: handle plain matrices of JuMP variables
-# Need to be more specific than AbstractMatrix to avoid ambiguity with MutableArithmetics
-function LinearAlgebra.dot(A::SparseMatrixCSC,
-                           B::Matrix{<:JuMP._MA.AbstractMutable})
-    acc = zero(eltype(B))
-
-    for j in 1:size(A, 2)
-        for k in nzrange(A, j)
-            add_to_expression!(acc, nonzeros(A)[k], B[rowvals(A)[k], j])
-        end
-    end
-
-    return acc
-end
-
-function LinearAlgebra.dot(A::Matrix{<:JuMP._MA.AbstractMutable},
+function LinearAlgebra.dot(A::Symmetric{<:JuMP._MA.AbstractMutable,Matrix{<:JuMP._MA.AbstractMutable}},
                            B::SparseMatrixCSC)
     return dot(B, A)
 end


### PR DESCRIPTION
## Summary

This PR adds Julia v1.12+ compatibility fixes for the `LinearAlgebra.dot` function when used with JuMP variables.

## Problem

Julia v1.12 introduced changes to the LinearAlgebra module that cause compatibility issues with QuantumNPA.jl when using JuMP variables in dot products.

## Solution

Update the relevant code to work correctly with Julia v1.12+ while maintaining backwards compatibility.

## Changes

- Fixed LinearAlgebra.dot compatibility with JuMP variables
- Tested with Julia v1.12.1

## Testing

- ✅ Tested with Julia v1.12.1
- ✅ Used in NCTSSOSBenchmark.jl for CHSH inequality benchmarks

## Related

This fix is being used in the NCTSSOSBenchmark.jl project which requires Julia v1.12+ compatibility for benchmarking quantum optimization problems.